### PR TITLE
Adds match-script and groovy-sandbox to Lockable Resources Plugin properties

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -1103,6 +1103,10 @@ def lockable_resources(registry, xml_parent, data):
     :arg int number: Number of resources to request, empty value or 0 means
         all. This is useful, if you have a pool of similar resources,
         from which you want one or more to be reserved. (default 0)
+    :arg str match-script: Groovy script to reserve resource based on its
+        properties. Leave empty to disable. (default None)
+    :arg bool groovy-sandbox: Execute the provided match-script in Groovy
+        sandbox. Leave empty to disable. (default False)
 
     Example:
 
@@ -1116,6 +1120,10 @@ def lockable_resources(registry, xml_parent, data):
 
     .. literalinclude::
         /../../tests/properties/fixtures/lockable_resources_full.yaml
+       :language: yaml
+
+    .. literalinclude::
+        /../../tests/properties/fixtures/lockable_resources_groovy.yaml
        :language: yaml
     """
     lockable_resources = XML.SubElement(
@@ -1131,6 +1139,13 @@ def lockable_resources(registry, xml_parent, data):
     ]
     helpers.convert_mapping_to_xml(
         lockable_resources, data, mapping, fail_required=True)
+    secure_groovy_script = XML.SubElement(lockable_resources, 'resourceMatchScript')
+    mapping = [
+        ('match-script', 'script', None),
+        ('groovy-sandbox', 'sandbox', False),
+    ]
+    helpers.convert_mapping_to_xml(secure_groovy_script, data, mapping,
+        fail_required=False)
 
 
 def docker_container(registry, xml_parent, data):

--- a/tests/properties/fixtures/lockable_resources_groovy.xml
+++ b/tests/properties/fixtures/lockable_resources_groovy.xml
@@ -2,12 +2,13 @@
 <project>
   <properties>
     <org.jenkins.plugins.lockableresources.RequiredResourcesProperty>
-      <resourceNames>the-resource</resourceNames>
-      <resourceNamesVar>RESOURCE_NAME</resourceNamesVar>
-      <resourceNumber>10</resourceNumber>
+      <resourceNames/>
+      <resourceNamesVar/>
+      <resourceNumber>0</resourceNumber>
       <labelName/>
       <resourceMatchScript>
-        <sandbox>false</sandbox>
+        <script>resourceName == MY_VAR</script>
+        <sandbox>true</sandbox>
       </resourceMatchScript>
     </org.jenkins.plugins.lockableresources.RequiredResourcesProperty>
   </properties>

--- a/tests/properties/fixtures/lockable_resources_groovy.yaml
+++ b/tests/properties/fixtures/lockable_resources_groovy.yaml
@@ -1,0 +1,5 @@
+---
+properties:
+  - lockable-resources:
+      match-script: "resourceName == MY_VAR"
+      groovy-sandbox: true

--- a/tests/properties/fixtures/lockable_resources_label.xml
+++ b/tests/properties/fixtures/lockable_resources_label.xml
@@ -6,6 +6,9 @@
       <resourceNamesVar/>
       <resourceNumber>0</resourceNumber>
       <labelName>pool-1</labelName>
+      <resourceMatchScript>
+        <sandbox>false</sandbox>
+      </resourceMatchScript>
     </org.jenkins.plugins.lockableresources.RequiredResourcesProperty>
   </properties>
 </project>

--- a/tests/properties/fixtures/lockable_resources_minimal.xml
+++ b/tests/properties/fixtures/lockable_resources_minimal.xml
@@ -6,6 +6,9 @@
       <resourceNamesVar/>
       <resourceNumber>0</resourceNumber>
       <labelName/>
+      <resourceMatchScript>
+        <sandbox>false</sandbox>
+      </resourceMatchScript>
     </org.jenkins.plugins.lockableresources.RequiredResourcesProperty>
   </properties>
 </project>


### PR DESCRIPTION
Enables the capability of using a groovy script in the Lockable Resources plugin, in properties.

Updated and Provided examples.